### PR TITLE
data-* attribute rename

### DIFF
--- a/content/index.html
+++ b/content/index.html
@@ -135,7 +135,7 @@
 			<aside class="example" title="A browser extension for rendering symbols">
 				<p>A browser extension or stand-alone tool may have a mode that renders the appropriate symbol for an input label.</p> 
 				<code>
-					&lt;label for="home" <strong>data-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
+					&lt;label for="home" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
 					&lt;input type="textarea" id="home" name="address" autocomplete="street-address"&gt;
 				</code>	
 				<p>Where the symbol value 14855 maps back to "Home".</p>

--- a/content/index.html
+++ b/content/index.html
@@ -14,12 +14,12 @@
 				padding: 0.3em;
 			}
 		</style>
-	
+
 	</head>
 	<body>
 
 		<section id="abstract">
-            
+
 
 		                        <p>This specification provides web content authors a standard approach to support web users who are persons with various cognitive and learning disabilities who:</p>
 
@@ -31,7 +31,7 @@
 					<p>The technology described in this specification is intended to be used to programmatically transform the appearance of typical web content including form controls, icons, and other user interface elements	into a rendering incorporating an individual user's preferred AAC symbols. The W3C <a href="https://w3c.github.io/adapt-registry/">WAI-Adapt Symbols Registry</a> provides the required mappings between concept values used by content authors and the user's preferred AAC symbol set representation of that concept.</p>
 					                        <p>This WAI-Adapt: Content Module is a component of the WAI-Adapt series introduced in the <a href="https://www.w3.org/TR/adapt/">WAI-Adapt Explainer</a> document [[adapt]].</p>
 								                </section>
-										 
+
 		<section id="sotd"></section>
 
 		<section class="informative" id="introduction">
@@ -40,7 +40,7 @@
 			<section>
 				<h2>Background</h2>
 				<p>This specification module enables authors to add semantic information about content at the element level, in order to facilitate a more familiar and comprehensible interface for the individual user who requires AAC symbols support. Final renderings &mdash; generated via helper apps or 3rd-party tools &mdash; are ultimately defined by the user's configuration settings.</p>
-				
+
 				<p>The goal of the attribute and values described in this specification is to enable personalized communication and web content interaction for the individual user. This specification includes facilities to:</p>
 
 				<ul>
@@ -58,16 +58,13 @@
 			<section>
 				<h2>Vocabulary Structure and Implementations</h2>
 				<p>All the vocabulary in WAI-Adapt: Content Module is constructed of properties and their values. Please see our <a href="https://www.w3.org/TR/adapt/">WAI-Adapt Explainer</a>. </p>
-				<div class="ednote"><p>WAI-Adapt module specifications currently define and relies on multiple entity attributes
-					constructed according to the requirements of Sec. 3.2.6.6 of the HTML Specification, <a
-					href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes"> Embedding custom non visible data with the data-* attributes</a> and by express request of W3C's Technical Advisory Group (TAG). The HTML data- attribute syntax is not intended to be used for long-term wide-scale features. The task force is using this approach at the moment to gain implementation experience and demonstrate the usefulness of WAI-Adapt in practice.</p><p>Implementers are cautioned that the "data-" prefix will be removed or replaced for some or all attribute values in succeeding iterations of this specification following additional consideration in W3C and the WHATWG.</p></div>
 				<p>The vocabulary implementation included in this module specification is available at our <a href="https://github.com/w3c/adapt/wiki/Implementations-of-Semantics">implementations wiki page</a>.</p>
 				<section id="properties">
 				<h3>Properties</h3>
 				<p>Properties are the main units of WAI-Adapt types supported by the vocabulary. A given property supports a specific type of personalization. That property would only be used once on a given piece of content, but multiple different properties could be used on the same piece of content to address different needs.</p>
 				</section>
 				<section id="propcharacteristic_value">
-				<h3 id="vocabulary_values">Values</h3> 
+				<h3 id="vocabulary_values">Values</h3>
 				<p>Values provide the specific WAI-Adapt information for the property. The possible values for each property are elaborated in the definition of the property in the modules. Some properties require the value to come from a predefined list of possible values, others can accept arbitrary strings, and some may accept multiple values. The attribute value may be one of the following types:</p>
 				<dl>
 					<dt id="valuetype_idref">ID reference</dt>
@@ -87,11 +84,11 @@
 					<dt id="valuetype_uri">URI</dt>
 					<dd>A Uniform Resource Identifier as defined by <cite><a href="http://www.ietf.org/rfc/rfc3986.txt" id="bib-rfc3986">RFC 3986</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] It may reference a separate document, or a content fragment identifier in a separate document, or a content fragment identifier within the same document.</dd>
 				</dl>
-				</section>				
+				</section>
 				<p><strong>Note that the attributes and values in this specification do not override the semantics exposed in the accessibility tree, but rather augment them.</strong> In the case of conflict between an element's semantics and the attribute values, validation algorithms should issue a warning but not an error.</p>
 				 <div class="note">Since implementations have not yet been finalized, any examples in this document are illustrative only, and are provided to help in understanding the concept.  All examples will be updated once implementation examples are finalized.</div>
 			</section>
-			
+
 			<section>
 				<h2>Use Cases and Requirements</h2>
 				<p>The <a href="https://www.w3.org/TR/adapt-requirements/">Requirements document for WAI-Adapt</a> describes use cases and requirements which, in turn, are derived from the user scenarios and use cases published in the W3C Note, <a href="https://www.w3.org/TR/coga-usable/">Making Content Usable (for COGA People). This specification module provides one key component to fulfill those requirements related to adapting content to support AAC symbols.</p>
@@ -100,7 +97,7 @@
 		</section>
 		<section>
 			<h1>Terms</h1>
-			
+
 
 <!-- p>The Personalization Semantics Content Module uses term definitions from the Cognitive and Learning Disabilities Accessibility Task Force. See the <a href="https://www.w3.org/TR/coga-usable/#glossary">COGA Glossary</a>.</p -->
 
@@ -115,29 +112,29 @@
 
 		<section>
 			<h1>Vocabulary</h1>
-            
-			<section data-include="symbol.html" data-include-replace="true" id="symbol"></section>		
+
+			<section data-include="symbol.html" data-include-replace="true" id="symbol"></section>
 		</section>
 		<section>
 			<h1>Privacy and Security Considerations</h1>
 				<p>This specification adds context information about content to the document, and should not affect security.</p>
 
 				<p>Although this specification does not expose personal preferences and personal information, third party user agents or proxy server(s) acting upon our semantic information may need to store personal preferences on how to present content to a specific user. It is recommended that any user agent or proxy server implements best practices to protect all personal preferences and personal information.</p>
-		
+
 <p>Any user agent with user settings are recommended to follow best practices to keep user information secure.</p>
 		<p>The Privacy and Security Considerations of WAI-Adapt: Content Module is also discussed at <a href="https://github.com/w3c/adapt/issues/131">issue #131</a>.</p>
-		
+
 		</section>
 
 		<section class="appendix">
 			<h1>Candidate Recommendation Exit Criteria</h1>
 			<p>The WAI Adapt Content Module 1.0 specification consists of attributes that may be added to a page’s HTML at the website’s discretion. A user agent may take suitable rendering decisions based on these attributes.</p>
 			<aside class="example" title="A browser extension for rendering symbols">
-				<p>A browser extension or stand-alone tool may have a mode that renders the appropriate symbol for an input label.</p> 
+				<p>A browser extension or stand-alone tool may have a mode that renders the appropriate symbol for an input label.</p>
 				<code>
 					&lt;label for="home" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
 					&lt;input type="textarea" id="home" name="address" autocomplete="street-address"&gt;
-				</code>	
+				</code>
 				<p>Where the symbol value 14855 maps back to "Home".</p>
 			</aside>
 			<p>For the specification to exit Candidate Review status: for each attribute-value pair in the specification, at least two user agents (or extensions to existing user agents) react to the attribute in an identifiable manner which is suited to the semantics of the attribute.</p>
@@ -148,15 +145,12 @@
 				<li><p>The results of testing are made available in a separate <a href="
 					https://w3c.github.io/adapt/content/reports/">implementation report</a>.</p></li>
 			</ul>
-			<div class="ednote">
-				<p>As per the introductory section on <a href="#vocabulary-structure-and-implementations">Vocabulary Structure and Implementations</a>, with the publication of this Candidate Recommendation, the Working Group plans to document implementation of WAI-Adapt Content attributes using the <code>data-*</code> attribute syntax. Once implementability and usefulness is demonstrated, the WG will request a reserved prefix for HTML. It plans then to re-issue a Candidate Recommendation using the new attribute names. Implementations tested in the first CR will need to update the recognized attributes, and the stable attribute name will support new implementations.</p>
-			</div>
 		</section>
 
 
 		<div data-include="../common/acknowledgements.html" data-oninclude="fixIncludes" data-include-replace="true">Acknowledgements placeholder</div>
 
-		
+
 
 	</body>
 </html>

--- a/content/reports/index.html
+++ b/content/reports/index.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8" />
     <title>WAI-Adapt: Content Module Implementation report</title>
     <script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove" defer></script>
-   
     <script class="remove">
         var respecConfig = {
             specStatus: "base",
@@ -25,21 +24,18 @@
         };
     </script>
 </head>
-
 <body>
     <section id="abstract">
         <p>This document gives an overview of the various implementation reports corresponding.</p>
-        
     </section>
+
     <section id="sotd">
     </section>
 
     <section id="introduction">
       <h1>Introduction</h1>
-      <p>WAI-Adapt is using "data-*" approach at the moment to gain implementation experience and demonstrate the usefulness of WAI-Adapt in practice. Implementers are cautioned that the "data-" prefix will be removed or replaced for some or all attribute values in succeeding iterations of this specification following additional consideration in W3C and the WHATWG. See <a href="https://www.w3.org/TR/adapt/#vocabulary-implementations">implementation information in Explainer</a>.</p>
 
       <p>There are some early <a href="https://github.com/w3c/adapt/wiki/Implementations-of-Semantics">implementations of content</a> that can maximize the benefit for users.</p>
     </section>
-
 </body>
 </html>

--- a/content/symbol.html
+++ b/content/symbol.html
@@ -33,13 +33,13 @@
 		<p>Here are some examples using the <code>symbol</code> attribute.</p>
 		<ol>
 			<li>Symbols for individual words.
-				<pre class="example" title="Symbols for individual words">&lt;span data-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span data-symbol=&quot;17511&quot;&gt;Tea&lt;/span&gt;</pre>
+				<pre class="example" title="Symbols for individual words">&lt;span adapt-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span adapt-symbol=&quot;17511&quot;&gt;Tea&lt;/span&gt;</pre>
 			</li>
 			<li>Symbols used with an image (<code>alt</code> text represented as a symbol).
-				<pre class="example" title="Symbols used with an image">&lt;img src="cup.png" data-symbol="13621" alt="Cup"/&gt;</pre>
+				<pre class="example" title="Symbols used with an image">&lt;img src="cup.png" adapt-symbol="13621" alt="Cup"/&gt;</pre>
 			</li>
 			<li>Symbols with conjugation. In this example a symbol is used for "her name" for the conjugated Hebrew word, <span lang="he" dir="rtl">שמה</span>. The plus sign is used with no spaces to join the conjugated values, "her" (14707) and "name" (15691). If the gender is not important, you can just use the value for name (15691).
-				<pre class="example" title="Symbols with conjugation">&lt;img src="her-name.png" alt="שמה" data-symbol="15691+14707"/></pre>
+				<pre class="example" title="Symbols with conjugation">&lt;img src="her-name.png" alt="שמה" adapt-symbol="15691+14707"/></pre>
 			</li>
 		</ol>
 	</section>

--- a/help/alternative.html
+++ b/help/alternative.html
@@ -21,7 +21,7 @@
 		<p>The below example section show how <code>alternative</code> used when coding.</p>
     <pre class="example" title="Alternative Using data-">
     &lt;div&gt;
-	&lt;span data-alternative="easylang numberfree vocab1000" class="hidden"&gt;
+	&lt;span adapt-alternative="easylang numberfree vocab1000" class="hidden"&gt;
  	   most people prefer simple text
   	&lt;/span&gt;
         In studies it was found that only 30% of users prefer long convoluted text

--- a/help/alternative.html
+++ b/help/alternative.html
@@ -19,7 +19,7 @@
 	<section id="alternative-example">
     <h3>Example</h3>
 		<p>The below example section show how <code>alternative</code> used when coding.</p>
-    <pre class="example" title="Alternative Using data-">
+    <pre class="example" title="alternative using adapt-">
     &lt;div&gt;
 	&lt;span adapt-alternative="easylang numberfree vocab1000" class="hidden"&gt;
  	   most people prefer simple text

--- a/help/easylang.html
+++ b/help/easylang.html
@@ -14,7 +14,7 @@
 	<section id="easylang-example">
 		<h3>Example</h3>
 		<p>The below example section show how <code>easylang</code> used when coding.</p>
-   		<pre class="example" title="Easylang Using data-">
+   		<pre class="example" title="easylang using adapt-">
 			&lt;span adapt-easylang="some text that is easy to read"> some convoluted obtuse text&lt;/span&gt;</pre>
     </section>
     <section>

--- a/help/easylang.html
+++ b/help/easylang.html
@@ -15,7 +15,7 @@
 		<h3>Example</h3>
 		<p>The below example section show how <code>easylang</code> used when coding.</p>
    		<pre class="example" title="Easylang Using data-">
-			&lt;span data-easylang="some text that is easy to read"> some convoluted obtuse text&lt;/span&gt;</pre>
+			&lt;span adapt-easylang="some text that is easy to read"> some convoluted obtuse text&lt;/span&gt;</pre>
     </section>
     <section>
     	<h3>Characteristics</h3>

--- a/help/explain.html
+++ b/help/explain.html
@@ -12,7 +12,7 @@
 	<section id="explain-example">
 		<h3>Example</h3>
 		<p>The example section below shows how <code>explain</code> used when coding.</p>
-  		<pre class="example" title="Explain Using data-">
+  		<pre class="example" title="explain using adapt-">
 			adapt-explain="press enter to send the email" </pre>
 
     </section>

--- a/help/explain.html
+++ b/help/explain.html
@@ -13,7 +13,7 @@
 		<h3>Example</h3>
 		<p>The example section below shows how <code>explain</code> used when coding.</p>
   		<pre class="example" title="Explain Using data-">
-			data-explain="press enter to send the email" </pre>
+			adapt-explain="press enter to send the email" </pre>
 
     </section>
     <section>

--- a/help/extrahelp.html
+++ b/help/extrahelp.html
@@ -13,7 +13,7 @@
 	<section id="extrahelp-example">
 		<h3>Example</h3>
 		<p>The example section below shows how <code>extrahelp</code> would be used when coding.</p>
-    	<pre class="example" title="Extrahelp Using data-">
+    	<pre class="example" title="extrahelp using adapt-">
 			N/A - Example Needed</pre>
 
     </section>

--- a/help/feedback.html
+++ b/help/feedback.html
@@ -11,7 +11,7 @@
 		<h3>Example</h3>
 		<p>The example section below shows how <code>feedback</code> might be used when coding.</p>
    		<pre class="example" title="Feedback Using data-">
-			data-feedback="your email on %topic% was sent" </pre>
+			adapt-feedback="your email on %topic% was sent" </pre>
 
     </section>
     <section>

--- a/help/feedback.html
+++ b/help/feedback.html
@@ -10,7 +10,7 @@
 	<section id="feedback-example">
 		<h3>Example</h3>
 		<p>The example section below shows how <code>feedback</code> might be used when coding.</p>
-   		<pre class="example" title="Feedback Using data-">
+   		<pre class="example" title="feedback using adapt-">
 			adapt-feedback="your email on %topic% was sent" </pre>
 
     </section>

--- a/help/helptype.html
+++ b/help/helptype.html
@@ -19,19 +19,19 @@
 		<h3>Example</h3>
 	<p>The below example section show how <code>helptype</code> used when coding.</p>
 <pre class="example"title="Helptype Using data-">
-    &lt;button type="button" data-extrahelp=&quot;uri2 uri3&quot; &gt;undo&lt;/button&gt;
+    &lt;button type="button" adapt-extrahelp=&quot;uri2 uri3&quot; &gt;undo&lt;/button&gt;
 <p>URI 2 may read: </p>
-    &lt;div id=&quot;uri2&quot; data-helptype=&quot;morehelp&quot; data-hidden=&quot;true&quot;&gt;
+    &lt;div id=&quot;uri2&quot; adapt-helptype=&quot;morehelp&quot; adapt-hidden=&quot;true&quot;&gt;
         pressing the undo button will erase all your work on this page.
         Use this button with care.
         If you press it by mistake, press control and y at the same time
         and your answers will come back.
     &lt;/div&gt;
 
-&lt;a href=&quot;functiongethelp()&quot; data-helptype=&quot;humanhelp&quot; data-hidden=&quot;true&quot;&gt;
+&lt;a href=&quot;functiongethelp()&quot; adapt-helptype=&quot;humanhelp&quot; adapt-hidden=&quot;true&quot;&gt;
   I want a person to help me&lt;/a&gt;
 
-&lt;div id=&quot;uri3&quot; data-extrahelp=&quot;glossary&quot; data-hidden=&quot;true&quot;&gt;
+&lt;div id=&quot;uri3&quot; adapt-extrahelp=&quot;glossary&quot; adapt-hidden=&quot;true&quot;&gt;
 </pre>
 
     </section>

--- a/help/helptype.html
+++ b/help/helptype.html
@@ -18,7 +18,7 @@
 	<section id="helptype-example">
 		<h3>Example</h3>
 	<p>The below example section show how <code>helptype</code> used when coding.</p>
-<pre class="example"title="Helptype Using data-">
+<pre class="example"title="helptype using adapt-">
     &lt;button type="button" adapt-extrahelp=&quot;uri2 uri3&quot; &gt;undo&lt;/button&gt;
 <p>URI 2 may read: </p>
     &lt;div id=&quot;uri2&quot; adapt-helptype=&quot;morehelp&quot; adapt-hidden=&quot;true&quot;&gt;

--- a/help/index.html
+++ b/help/index.html
@@ -32,8 +32,7 @@
 			<h1>Introduction</h1>
 			<section id="background">
 				<h2>Background</h2>
-			<p>This document lists examples of the personalized help and support properties, this is an extension of <a href="../">WAI-Adapt Explainer</a>, including the properties of <code>literal</code>, <code>numberfree</code>, <code>easylang</code>, <code>alternative</code>, <code>explain</code>, <code>feedback</code>, <code>moreinfo</code>, <code>extrahelp</code>, <code>helptype</code>. </p>	
-			<p class="ednote" id="examples-disclaimer">WAI-Adapt defines a set of properties and values to annotate content. The specific mechanism to apply these properties to content and semantics has not been decided. <a href="https://github.com/w3c/personalization-semantics/wiki/Comparison-of-ways-to-use-vocabulary-in-content">Several approaches are under consideration</a> and future drafts will show progress. To help understand the proposed properties, this document provides many examples of WAI-Adapt applied to content, which show attributes beginning with the prefix "data-". <em>This prefix has not been decided on as the definitive approach</em>, but is used as a way to illustrate the examples.</p>
+			<p>This document lists examples of the personalized help and support properties, this is an extension of <a href="../">WAI-Adapt Explainer</a>, including the properties of <code>literal</code>, <code>numberfree</code>, <code>easylang</code>, <code>alternative</code>, <code>explain</code>, <code>feedback</code>, <code>moreinfo</code>, <code>extrahelp</code>, <code>helptype</code>. </p>
 			</section>
 			<section id="module">
 				<h2>WAI-Adapt: Help and Support Module</h2>
@@ -48,7 +47,7 @@
 				<p>Properties are the main units of WAI-Adapt types supported by the vocabulary. A given property supports a specific type of WAI-Adapt. That property would only be used once on a given piece of content, but multiple different properties could be used on the same piece of content to address different needs.</p>
 				</section>
 				<section id="propcharacteristic_value">
-				<h3 id="vocabulary_values">Values</h3> 
+				<h3 id="vocabulary_values">Values</h3>
 				<p>Values provide the specific personalization information for the property. The possible values for each property are elaborated in the definition of the property in the modules. Some properties require the value to come from a predefined list of possible values, others can accept arbitrary strings, and some may accept multiple values. The attribute value may be one of the following types:</p>
 				<dl>
 					<dt id="valuetype_idref">ID reference</dt>
@@ -68,10 +67,10 @@
 					<dt id="valuetype_uri">URI</dt>
 					<dd>A Uniform Resource Identifier as defined by <cite><a href="http://www.ietf.org/rfc/rfc3986.txt" id="bib-rfc3986">RFC 3986</a></cite> [<cite><a class="bibref" data-link-type="biblio" href="#bib-rfc3986" title="Uniform Resource Identifier (URI): Generic Syntax">RFC3986</a></cite>] It may reference a separate document, or a content fragment identifier in a separate document, or a content fragment identifier within the same document.</dd>
 				</dl>
-				</section>			
+				</section>
 				<p><strong>Note that the attributes and values in this specification do not overide the semantics exposed in the accessibility tree, but rather augment them.</strong> In the case of conflict between an element's semantics and the attribute values, validation algorithms should issue a warning but not an error.</p>
 				<div class="ednote">Since implementations have not yet been finalized, any examples in this document are illustrative only, and are provided to help in understanding the concept.  All examples will be updated once implementation examples are finalized.</div>
-			</section>		
+			</section>
 			<section id="usecases">
 				<h2>Use Cases and Requirements</h2>
 				<p>The <a href="https://github.com/w3c/personalization-semantics/wiki/Requirements">Requirements for Personalization Semantics</a> describes use cases and requirements. This module provides properties to fulfill those requirements related to adapting content.</p>
@@ -104,8 +103,8 @@
 						<section data-include="feedback.html" data-include-replace="true" id="feedback"></section>
 						<section data-include="moreinfo.html" data-include-replace="true" id="moreinfo"></section>
 						<section data-include="extrahelp.html" data-include-replace="true" id="extrahelp"></section>
-					</section>		
-			</section>	
+					</section>
+			</section>
 		</section>
 		<section id="privacy">
 			<h1>Privacy and Security Considerations</h1>

--- a/help/literal.html
+++ b/help/literal.html
@@ -14,7 +14,7 @@
 	<section id="literal-example">
 		<h3>Example</h3>
 		<p>The below example section show how <code>literal</code> used when coding.</p>
-    	<pre class="example" title="Literal Using data-">
+    	<pre class="example" title="literal using adapt-">
     	   It is &lt;span adapt-literal="raining hard">raining cats and dogs&lt;/span&gt;</pre>
     </section>
     <section>

--- a/help/literal.html
+++ b/help/literal.html
@@ -15,7 +15,7 @@
 		<h3>Example</h3>
 		<p>The below example section show how <code>literal</code> used when coding.</p>
     	<pre class="example" title="Literal Using data-">
-    	   It is &lt;span data-literal="raining hard">raining cats and dogs&lt;/span&gt;</pre>
+    	   It is &lt;span adapt-literal="raining hard">raining cats and dogs&lt;/span&gt;</pre>
     </section>
     <section>
     	<h3>Characteristics</h3>

--- a/help/moreinfo.html
+++ b/help/moreinfo.html
@@ -13,7 +13,7 @@
 	<section id="moreinfo-example">
 		<h3>Example</h3>
 		<p>The example section below shows how <code>moreinfo</code> would be used when coding.</p>
-    	<pre class="example" title="Moreinfo Using data-">
+    	<pre class="example" title="moreinfo using adapt-">
 			N/A - Example needed.</pre>
 
     </section>

--- a/help/numberfree.html
+++ b/help/numberfree.html
@@ -14,10 +14,10 @@
 	<section id="numberfree-example">
 		<h3>Example</h3>
 		<p>The below example section show how <code>numberfree</code> used when coding.</p>
-  		  <pre class="example" title="Numberfree Using data-">
+  		  <pre class="example" title="numberfree using adapt-">
 			&lt;span adapt-numberfree=&quot;almost all&quot;&gt;9 out of 10 &lt;/span&gt;</pre>
 	
-			<pre class="example" title="Numberfree Using data-">
+			<pre class="example" title="numberfree using adapt-">
 			&lt;span adapt-numberfree=&quot;hat and coat weather&quot;&gt;The weather is 9 degrees&lt;/span&gt;</pre>
     </section>
     <section>

--- a/help/numberfree.html
+++ b/help/numberfree.html
@@ -15,10 +15,10 @@
 		<h3>Example</h3>
 		<p>The below example section show how <code>numberfree</code> used when coding.</p>
   		  <pre class="example" title="Numberfree Using data-">
-			&lt;span data-numberfree=&quot;almost all&quot;&gt;9 out of 10 &lt;/span&gt;</pre>
+			&lt;span adapt-numberfree=&quot;almost all&quot;&gt;9 out of 10 &lt;/span&gt;</pre>
 	
 			<pre class="example" title="Numberfree Using data-">
-			&lt;span data-numberfree=&quot;hat and coat weather&quot;&gt;The weather is 9 degrees&lt;/span&gt;</pre>
+			&lt;span adapt-numberfree=&quot;hat and coat weather&quot;&gt;The weather is 9 degrees&lt;/span&gt;</pre>
     </section>
     <section>
     	<h3>Characteristics</h3>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 
 				<div  class="example"><p>Example: The user wants to get the latest weather report for their city and goes to a weather website.</p>
 				<p>Finding the actual weather forecast is actually a little challenging even if you have no disabilities due to all the additional content on the screen; along with advertisements, there is also the day's top stories, trending news, and social media to cognitively filter. If you are easily overwhelmed or distracted getting the key information about today's weather is a challenge. Having the ability to personalize and prioritize all but the key information (i.e. just the weather forecast for my city) is critical for this user.</p></div>
-				<p>In this example, the author can mark the <code>&lt;section&gt;</code>, <code>&lt;p&gt;</code>, or <code>&lt;div&gt;</code> that contains the actual weather report and any associated tools to manipulate the weather report (i.e. city search, hourly vs. 5 day forecast, etc.) with the <code>data-simplification</code> attribute (with a value of "critical"), and mark the other on-screen content as "medium" (default) or "low". (e.g. <code>&lt;p adapt-simplification="critical"&gt;</code><em>Today’s forecast is a high of 95&#176; and a low of 40&#176;</em><code>&lt;/p&gt;</code>)
+				<p>In this example, the author can mark the <code>&lt;section&gt;</code>, <code>&lt;p&gt;</code>, or <code>&lt;div&gt;</code> that contains the actual weather report and any associated tools to manipulate the weather report (i.e. city search, hourly vs. 5 day forecast, etc.) with the <code>adapt-simplification</code> attribute (with a value of "critical"), and mark the other on-screen content as "medium" (default) or "low". (e.g. <code>&lt;p adapt-simplification="critical"&gt;</code><em>Today’s forecast is a high of 95&#176; and a low of 40&#176;</em><code>&lt;/p&gt;</code>)
 
 				<p>For websites which rely on advertising revenue, it may be undesirable to completely suppress advertisements. We envision that this attribute could also facilitate relocating the most critical sections of a website above anything that is a lower priority. (i.e. Content re-ordering)</p>
 			</section>
@@ -105,7 +105,7 @@
 				</ul>
 				<p>Next to the humidity index of 90%, there could be a text alternative of “muggy”.</p>
 				</div>
-				<p>In this example, the author would mark up the numbers using the <code>data-numberfree</code> attribute. The default would show the numeric value. Those needing an alternative representation for numbers, would get an associated image or description/values as simplified text instead.</p>
+				<p>In this example, the author would mark up the numbers using the <code>adapt-numberfree</code> attribute. The default would show the numeric value. Those needing an alternative representation for numbers, would get an associated image or description/values as simplified text instead.</p>
 
 				<p>It is important to note that people with dyscalculia are often very good with words, so long text can be better than short numbers.</p>
 			</section>
@@ -131,7 +131,7 @@
 			<li>People who know different symbol sets wish to talk to each other.</li>
 			<li>A government agency creating information sheets about human rights and patient rights are seeking feedback from impacted users. They add symbols from a common symbol set to support a majority of different users. The agency would prefer to use a common symbol reference to support people who use or require different symbols. This allows all symbol set users to both read and edit the content.	</li>
 			</ul>
-			<div class="example"><p>Example: Using the <code>data-symbol</code> attribute, an author programmatically tags the label for a form input with the appropriate symbol value. Based on user preference settings, a browser helper application or stand-alone tool could then render that label using an appropriate symbol, alternative term, and/or furnishes an additional tool-tip that is understandable by the individual user. Using the <a href="https://www.blissymbolics.org/">Bliss Symbolics</a> set's unique reference numbers as our 'taxonomy', other symbol sets can map their equivalent symbols against the Bliss set.</p>
+			<div class="example"><p>Example: Using the <code>adapt-symbol</code> attribute, an author programmatically tags the label for a form input with the appropriate symbol value. Based on user preference settings, a browser helper application or stand-alone tool could then render that label using an appropriate symbol, alternative term, and/or furnishes an additional tool-tip that is understandable by the individual user. Using the <a href="https://www.blissymbolics.org/">Bliss Symbolics</a> set's unique reference numbers as our 'taxonomy', other symbol sets can map their equivalent symbols against the Bliss set.</p>
 
 			<code>
 			&lt;label for="bar" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
@@ -140,8 +140,8 @@
 			<p>Where the symbol value 14855 maps back to "Home".</p>
 			</div>
 <h4>Proof of Concept: Symbol Example</h4>
-<p>In the screen shots below, a browser extension uses the <code>data-symbol</code> attribute to load symbols that are familiar to the user.</p>	
-				<p>Note that users learn a specific symbol vocabulary. However, the various symbol vocabularies are mutually unintelligible: users familiar with one set of symbols may not be familiar with or understand an alternative set. WAI-Adapt's <code>data-symbol</code> attribute offers a mechanism to translate between symbol sets, to allow people to communicate with one another where it was previously not possible.</p>	
+<p>In the screen shots below, a browser extension uses the <code>adapt-symbol</code> attribute to load symbols that are familiar to the user.</p>	
+				<p>Note that users learn a specific symbol vocabulary. However, the various symbol vocabularies are mutually unintelligible: users familiar with one set of symbols may not be familiar with or understand an alternative set. WAI-Adapt's <code>adapt-symbol</code> attribute offers a mechanism to translate between symbol sets, to allow people to communicate with one another where it was previously not possible.</p>	
 
 			<figure>
 				<img src="https://user-images.githubusercontent.com/8376341/79741687-5b20a880-830a-11ea-814d-97ed7132d7d1.png" alt="screen shot, no symbols" style="height:95%; width:95%">
@@ -176,7 +176,7 @@
                     <li>Develop an API for browsers or other user-agents</li>
                     <li>Develop or produce supporting technology (browser extension, stand-alone software, etc.)</li>
                     <li>Develop or produce an authoring tool to support the new attributes</li>
-                    <li>Produce a symbol set for <code>data-symbol</code></li>
+                    <li>Produce a symbol set for <code>adapt-symbol</code></li>
                 </ul>
                 <p>We encourage a the development of these items and a list of implementations can be found on <a href="https://github.com/w3c/adapt/wiki">our wiki</a>.</p>
             </section>
@@ -254,10 +254,10 @@ will include use cases and vocabularies. At this time only one specification mod
             <p>At the present stage of development, the WAI-Adapt vocabulary can be used in HTML content using <a href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes">data-* attributes</a> [[html5]]. Attributes in this form can be used in valid HTML to implement features recognized by browser extensions or other special processors. WAI-Adapt is using this approach to gain early implementation experience of the features in a way that is simple and likely to be accepted within the web ecosystem as an interim approach.</p>
             <p>This publication of the WAI-Adapt provides several <em>key-value pairs</em> (attribute = value). These attributes include but are not limted to:</p>
             <ul>
-                <li><a href="content/#action-explanation">data-action</a></li>
-                <li><a href="content/#destination-explanation">data-destination</a></li>
-                <li><a href="content/#purpose-explanation">data-purpose</a></li>
-                <li><a href="content/#symbol-explanation">data-symbol</a></li>
+                <li><a href="content/#action-explanation">adapt-action</a></li>
+                <li><a href="content/#destination-explanation">adapt-destination</a></li>
+                <li><a href="content/#purpose-explanation">adapt-purpose</a></li>
+                <li><a href="content/#symbol-explanation">adapt-symbol</a></li>
             </ul>
             <p>Other properties exist or will be developed as the modules mature. See the discussion <a href="https://github.com/w3c/adapt/wiki/Prototypes-with-data-dash-*-(Take-2)">Prototypes with data dash</a>.</p>
             <div class="ednote"><p>The WAI-Adapt specification currently defines and relies on multiple entity attributes

--- a/index.html
+++ b/index.html
@@ -258,7 +258,7 @@ will include use cases and vocabularies. At this time only one specification mod
                 <li><a href="content/#purpose-explanation">adapt-purpose</a></li>
                 <li><a href="content/#symbol-explanation">adapt-symbol</a></li>
             </ul>
-            <p>Other properties exist or will be developed as the modules mature..</p>
+            <p>Other properties exist or will be developed as the modules mature.</p>
 			</section>
 			<section class="section">
                 <h2>Technology Comparison Summary</h2>

--- a/index.html
+++ b/index.html
@@ -81,7 +81,7 @@
 
 				<div  class="example"><p>Example: The user wants to get the latest weather report for their city and goes to a weather website.</p>
 				<p>Finding the actual weather forecast is actually a little challenging even if you have no disabilities due to all the additional content on the screen; along with advertisements, there is also the day's top stories, trending news, and social media to cognitively filter. If you are easily overwhelmed or distracted getting the key information about today's weather is a challenge. Having the ability to personalize and prioritize all but the key information (i.e. just the weather forecast for my city) is critical for this user.</p></div>
-				<p>In this example, the author can mark the <code>&lt;section&gt;</code>, <code>&lt;p&gt;</code>, or <code>&lt;div&gt;</code> that contains the actual weather report and any associated tools to manipulate the weather report (i.e. city search, hourly vs. 5 day forecast, etc.) with the <code>data-simplification</code> attribute (with a value of "critical"), and mark the other on-screen content as "medium" (default) or "low". (e.g. <code>&lt;p data-simplification="critical"&gt;</code><em>Today’s forecast is a high of 95&#176; and a low of 40&#176;</em><code>&lt;/p&gt;</code>)
+				<p>In this example, the author can mark the <code>&lt;section&gt;</code>, <code>&lt;p&gt;</code>, or <code>&lt;div&gt;</code> that contains the actual weather report and any associated tools to manipulate the weather report (i.e. city search, hourly vs. 5 day forecast, etc.) with the <code>data-simplification</code> attribute (with a value of "critical"), and mark the other on-screen content as "medium" (default) or "low". (e.g. <code>&lt;p adapt-simplification="critical"&gt;</code><em>Today’s forecast is a high of 95&#176; and a low of 40&#176;</em><code>&lt;/p&gt;</code>)
 
 				<p>For websites which rely on advertising revenue, it may be undesirable to completely suppress advertisements. We envision that this attribute could also facilitate relocating the most critical sections of a website above anything that is a lower priority. (i.e. Content re-ordering)</p>
 			</section>
@@ -115,7 +115,7 @@
 				<p>Those who have a moderate Language Impairment / Learning Disability may have a limited vocabulary. They will only know terms that are in the core vocabulary they have learned. They may also use symbols to represent words and concepts.</p>
 
 				<div class="example"><p>Example: The user may know the word "name" or "last name" but not recognize the term "family name" or "surname" as cognates.</p><p> For some users, learning new terms is a very slow process, requiring hours of work. For these users, reading web content may also be a very slow process, so that finding the information desired on some particular web page can present a laborious barrier. The ability to personalize a web page and present symbols instead, or alongside content can help some users better and more promptly understand the content being provided</p></div>
-				<p>Note that some people with language disabilities are good at numbers. They will want a long string of text replaced with a short number: <code>&lt;span <strong>data-easylang="90% of the time this happens"</strong>&gt; normally this is the expected outcome&lt;/span&gt;</code>. This is the opposite of the numberfree example.</p>
+				<p>Note that some people with language disabilities are good at numbers. They will want a long string of text replaced with a short number: <code>&lt;span <strong>adapt-easylang="90% of the time this happens"</strong>&gt; normally this is the expected outcome&lt;/span&gt;</code>. This is the opposite of the numberfree example.</p>
 
 				<p>Additionally, because reading content for some users is extremely time-consuming, they may also want less content and fewer features on a given web page.<p>
 			</section>
@@ -134,8 +134,8 @@
 			<div class="example"><p>Example: Using the <code>data-symbol</code> attribute, an author programmatically tags the label for a form input with the appropriate symbol value. Based on user preference settings, a browser helper application or stand-alone tool could then render that label using an appropriate symbol, alternative term, and/or furnishes an additional tool-tip that is understandable by the individual user. Using the <a href="https://www.blissymbolics.org/">Bliss Symbolics</a> set's unique reference numbers as our 'taxonomy', other symbol sets can map their equivalent symbols against the Bliss set.</p>
 
 			<code>
-			&lt;label for="bar" <strong>data-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
-			&lt;input type="textarea" id="bar" name="address" data-purpose="street-address"&gt;
+			&lt;label for="bar" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
+			&lt;input type="textarea" id="bar" name="address" adapt-purpose="street-address"&gt;
 			</code>	
 			<p>Where the symbol value 14855 maps back to "Home".</p>
 			</div>

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
 		<script src="https://www.w3.org/Tools/respec/respec-w3c" class="remove"></script>
 		<script src="common/biblio.js" class="remove"></script>
 		<script src="respec-config.js" class="remove"></script>
-	
+
 		<link href="common/css/common.css" rel="stylesheet" type="text/css" />
 	</head>
 	<body>
@@ -33,15 +33,15 @@
 			</ul>
 			<p>Personalization involves tailoring aspects of the user experience to meet the preferences or needs of individual users. For example, having familiar terms and symbols is critical for effective use of web content for many as described in the user scenarios and use cases published in the <a href="https://www.w3.org/TR/coga-usable/">Making Content Usable (for COGA people)</a>. However what is familiar to one user will inevitably be new and foreign to another. Personalization based on WAI-Adapt AAC symbol support technologies supports loading a set of symbols that is appropriate for the specific user, ensuring that each user is presented with familiar symbols.</p>
 			<p>Technology holds the promise of being extremely flexible and the design of many systems includes the expectation that users can optimize their interaction experience according to their personal preferences or accessibility needs. </p>
-			
+
 			<section class="section" id="why_accessibility">
 				<h2>Why We Need WAI-Adapt</h2>
 				<p>WAI-Adapt will allow assitive technology to: </p>
 				<ol>
 					<li>adapt to and meet the user's needs. Users who have difficulty with established, mainstream patterns can interact with interfaces modified to their preferences and abilities. </li>
 					<li>modify levels of complexity as people's skills improve or decline over time. For example, extra support may be critical for some people but distracting for others.</li>
-	
-					<li>provide better support to users who require: 				
+
+					<li>provide better support to users who require:
 					<ul>
 						<li>familiar and consistent symbols, iconography, and graphics </li>
 						<li>tooltips or similar on-demand help or clues</li>
@@ -66,7 +66,7 @@
 			<section>
 			<h2>Use Case Examples</h2>
 				<p><a href="requirements/">Requirements for WAI-Adapt</a> elaborates many use cases that further contextualize the above summary of user needs. These example use cases form the basis of requirements for this technology. WAI-Adapt enables developers to create targeted extensions as additional use cases are encountered.</p>
-				
+
                 <p>Examples</p>
                 <ul>
                 	<li><a href="#distracted">Easily Distracted / Overwhelmed</a></li>
@@ -85,7 +85,7 @@
 
 				<p>For websites which rely on advertising revenue, it may be undesirable to completely suppress advertisements. We envision that this attribute could also facilitate relocating the most critical sections of a website above anything that is a lower priority. (i.e. Content re-ordering)</p>
 			</section>
-				
+
 			<p>WAI-Adapt recognizes that appropriate simplification will often be task determined. A complex page will often support multiple tasks each of which could be critical to the user requiring simplification at different times. We propose to investigate how we might  facilitate users defining what task is critical to them in the moment rather than pre-determining what is primary or secondary in advance.</p>
 
 			<section class="section" id="difficulty_numbers">
@@ -109,7 +109,7 @@
 
 				<p>It is important to note that people with dyscalculia are often very good with words, so long text can be better than short numbers.</p>
 			</section>
-			
+
 			<section class="section" id="learning_disability">
 			<h3>Mild-Moderate Language Impairment / Learning Disability</h3>
 				<p>Those who have a moderate Language Impairment / Learning Disability may have a limited vocabulary. They will only know terms that are in the core vocabulary they have learned. They may also use symbols to represent words and concepts.</p>
@@ -119,7 +119,7 @@
 
 				<p>Additionally, because reading content for some users is extremely time-consuming, they may also want less content and fewer features on a given web page.<p>
 			</section>
-			
+
 			<section class="section" id="language_impairment">
 			<h3>Severe Language Impairment</h3>
 			<p>Some users with a severe speech and/or physical impairment may communicate using symbols, rather than written text, as part of an Augmentative and Alternative Communication (AAC) system. The use of symbols to represent words is their primary means of communication when both consuming and producing information. Symbol users face a wide variety of barriers to accessing web content, but one of the main challenges is a lack of standard inter-operability between different proprietary symbol sets, or a mechanism for translating the same concept from one symbol set to another.</p>
@@ -136,12 +136,12 @@
 			<code>
 			&lt;label for="bar" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
 			&lt;input type="textarea" id="bar" name="address" adapt-purpose="street-address"&gt;
-			</code>	
+			</code>
 			<p>Where the symbol value 14855 maps back to "Home".</p>
 			</div>
 <h4>Proof of Concept: Symbol Example</h4>
-<p>In the screen shots below, a browser extension uses the <code>adapt-symbol</code> attribute to load symbols that are familiar to the user.</p>	
-				<p>Note that users learn a specific symbol vocabulary. However, the various symbol vocabularies are mutually unintelligible: users familiar with one set of symbols may not be familiar with or understand an alternative set. WAI-Adapt's <code>adapt-symbol</code> attribute offers a mechanism to translate between symbol sets, to allow people to communicate with one another where it was previously not possible.</p>	
+<p>In the screen shots below, a browser extension uses the <code>adapt-symbol</code> attribute to load symbols that are familiar to the user.</p>
+				<p>Note that users learn a specific symbol vocabulary. However, the various symbol vocabularies are mutually unintelligible: users familiar with one set of symbols may not be familiar with or understand an alternative set. WAI-Adapt's <code>adapt-symbol</code> attribute offers a mechanism to translate between symbol sets, to allow people to communicate with one another where it was previously not possible.</p>
 
 			<figure>
 				<img src="https://user-images.githubusercontent.com/8376341/79741687-5b20a880-830a-11ea-814d-97ed7132d7d1.png" alt="screen shot, no symbols" style="height:95%; width:95%">
@@ -156,7 +156,7 @@
 				<figcaption>The same page loaded, but the user-agent has removed content and added different symbols that this user is more familiar with</figcaption>
 			</figure>
 		</section>
-		
+
 		<section class="section" id="memory_impairment">
 			<h3>Working Memory and Short-term Memory Impairment</h3>
 			<p>Users may have differences in both working and short-term memory.  For some users the number of items that can be held in working memory is a fraction of the amound most users can hold in memory. Whereas most adults can repeat about seven digits in correct order, some users may only manage two or three digits. When these users become distracted, they are also likely to forget any information in their working memory.</p>
@@ -165,10 +165,10 @@
 
 			<p>A step indicator allows an author to define steps within a process or represent an entire user path outside of the context of a defined process. This includes turning steps between defined processes into breadcrumbs or linked steps that identify completed tasks. This allows the user to navigate back to completed steps and identify a user's current location in a path.</p>
 
-			<p>More information on personas and user needs can be found in  <a href="https://www.w3.org/TR/coga-usable/" rel="nofollow">Making Content Usable for People with Cognitive and Learning Disabilities</a>.</p> 
+			<p>More information on personas and user needs can be found in  <a href="https://www.w3.org/TR/coga-usable/" rel="nofollow">Making Content Usable for People with Cognitive and Learning Disabilities</a>.</p>
 		</section>
 	</section>
-            
+
             <section>
             <h2>Out of Scope</h2>
                 <p>While the intention of this work is to introduce a new set of attributes to support WAI-Adapt, the following work items are out of scope:</p>
@@ -180,8 +180,8 @@
                 </ul>
                 <p>We encourage a the development of these items and a list of implementations can be found on <a href="https://github.com/w3c/adapt/wiki">our wiki</a>.</p>
             </section>
-            
-           
+
+
 		</section>
 
 		<section >
@@ -196,15 +196,15 @@ will include use cases and vocabularies. At this time only one specification mod
 
 				<ul><li>
 					<p>Use-cases and vocabularies for identifying the purpose of controls, symbols and user interface elements, and supports simplification and avoiding distractions.</p></li>
-				
+
 					<li><a href="help/index.html">WAI-Adapt: Help and Support Module:</a>
 					<p>The first working draft of this module is now available.</p>
 					<p>This module addresses adding information about the content to enable help scaffolding and additional support for different user scenarios.</p></li>
-				
+
 					<li><a href="tools/index.html">WAI-Adapt: Tools Module:</a>
 					<p>The first working draft of this module is now available.</p>
 					<p>This module addresses adding information about the content to enable user-agents and extensions to provide additional support to the user. One example is adaptable breadcrumbs.</p></li>
-				
+
 				</ul>
 		</section>
 
@@ -237,7 +237,7 @@ will include use cases and vocabularies. At this time only one specification mod
 					<dd>A Uniform Resource Identifier as defined by <cite><a href="http://www.ietf.org/rfc/rfc3986.txt">RFC 3986</a></cite> [[RFC3986]]. It may reference a separate document, or a content fragment identifier in a separate document, or a content fragment identifier within the same document.</dd>
 				</dl>
 				<div class="note">The attributes and values in this specification are not intended to overide the semantics exposed in the Accessibility Tree, but rather augment them. In the case of conflict between an element's semantics and the attribute values, validation algorithms should issue a warning but not an error.</div>
-				
+
 			</section>
 		</section>
 
@@ -250,8 +250,7 @@ will include use cases and vocabularies. At this time only one specification mod
 			<h1>Vocabulary Implementations</h1>
 			<section class="section">
 			<h2>Current Usage</h2>
- 
-            <p>At the present stage of development, the WAI-Adapt vocabulary can be used in HTML content using <a href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes">data-* attributes</a> [[html5]]. Attributes in this form can be used in valid HTML to implement features recognized by browser extensions or other special processors. WAI-Adapt is using this approach to gain early implementation experience of the features in a way that is simple and likely to be accepted within the web ecosystem as an interim approach.</p>
+
             <p>This publication of the WAI-Adapt provides several <em>key-value pairs</em> (attribute = value). These attributes include but are not limted to:</p>
             <ul>
                 <li><a href="content/#action-explanation">adapt-action</a></li>
@@ -259,14 +258,11 @@ will include use cases and vocabularies. At this time only one specification mod
                 <li><a href="content/#purpose-explanation">adapt-purpose</a></li>
                 <li><a href="content/#symbol-explanation">adapt-symbol</a></li>
             </ul>
-            <p>Other properties exist or will be developed as the modules mature. See the discussion <a href="https://github.com/w3c/adapt/wiki/Prototypes-with-data-dash-*-(Take-2)">Prototypes with data dash</a>.</p>
-            <div class="ednote"><p>The WAI-Adapt specification currently defines and relies on multiple entity attributes
-constructed according to the requirements of Sec. 3.2.6.6 of the HTML Specification, <a
-href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visible-data-with-the-data-*-attributes"> Embedding custom non visible data with the data-* attributes</a> and by express request of W3C's Technical Advisory Group (TAG). The HTML data- attribute syntax is not intended to be used for long-term wide-scale features. The task force is using this approach at the moment to gain implementation experience and demonstrate the usefulness of WAI-Adapt in practice.</p><p>Implementers are cautioned that the "data-" prefix will be removed or replaced for some or all attribute values in succeeding iterations of this specification following additional consideration in W3C and the WHATWG.</p></div>
+            <p>Other properties exist or will be developed as the modules mature..</p>
 			</section>
 			<section class="section">
                 <h2>Technology Comparison Summary</h2>
-                <p>The task force reviewed various vocabulary options before deciding upon the use of the data- HTML attribute syntax.  The list of technologies included:</p>
+                <p>The task force reviewed various vocabulary options before deciding upon the use of the HTML attribute syntax.  The list of technologies included:</p>
                 <ul>
                     <li><a href="https://www.w3.org/TR/rdfa-lite/">RDFa Lite</a></li>
                     <li><a href="https://www.w3.org/TR/microdata/">HTML Microdata</a></li>
@@ -296,8 +292,7 @@ href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visib
 				</dl>
 
                 <p>The details of our research and discussion are documented on the <a href="https://github.com/w3c/adapt/wiki/Comparison-of-ways-to-use-vocabulary-in-content">Comparison of ways to use vocabulary in content</a> and <a href="https://github.com/w3c/adapt/wiki/Prototypes-with-data-dash-*-(Take-2)">Prototypes with data dash</a> pages in our Wiki. </p>
-                <p>We presented some of these options at the TPAC 2018 WAI-Adapt Plenary Day presentation and provided a working example using the data- attribute to add WAI-Adapt features. The data- solution was recommended by representatives of several working groups attending our presentation and discussions. See the <a href="https://w3c.github.io/adapt/#vocabulary-implementations">Vocabulary Implementations section in this Explainer document</a> for further details on the use of data- attributes.</p>
-                
+
             </section>
 		</section>
         <section>
@@ -313,10 +308,10 @@ href="https://html.spec.whatwg.org/multipage/dom.html#embedding-custom-non-visib
                 <li>Students who wish to develop a new software project that meets a real need</li>
                 <li>Policy makers who want to understand what is possible for inclusion</li>
             </ul>
-        
+
         <p>For early implementations of content we suggest including a link to an <a href="https://github.com/w3c/adapt/wiki/Implementations-of-Semantics">extension implementation</a> that can maximize the benefit for users.</p>
-         </section>   
-        
+         </section>
+
 		<!--
 
 		<section class="appendix" id="changelog">

--- a/tools/index.html
+++ b/tools/index.html
@@ -21,10 +21,10 @@
 					<ul>
 						<li>may get overwhelmed with the volume of on-screen messages, and wishes to filter out low priority messages and concentrate on critical priority messages;</li>
 						<li>need to remember completed tasks in order to identify their location in a process.</li>
-						
+
 					</ul>
 			<p>The technology described in this specification is intended to be used to programmatically transform the appearance of typical web content including form controls, icons, and other user interface elements	into a rendering more familiar and comprehensible to an individual user. Use cases and relevant vocabulary terms are defined which allow user agents to augment or adapt content to better fit a particular user's particular needs. This helps users with varying needs to understand web content more readily, by simplifying the web interaction, or by avoiding forcing the user to grapple with unfamiliar representations they are ill equipped to comprehend.</p>
-			
+
 			<p>This WAI-Adapt: Tools Module is a component of the WAI-Adapt series introduced in the <a href="../">WAI-Adapt Explainer</a> document [[personalization-semantics-1.0]].</p>
 		</section>
 
@@ -35,10 +35,8 @@
 			<section id="background">
 				<h2>Background</h2>
 				<p>This specification module enables authors to add semantic information about content at the element level, in order to indicate the priority level of a message for the individual user, or programmatically enumerate tasks that the user is required to complete, so that users who have memory issues can keep track of the steps previously completed. It is anticipated that multiple screen renderings (transformations) will be supported in order to meet the differing needs of different users. Final renderings &mdash; generated via helper apps or 3rd-party tools &mdash; will be ultimately defined by the user's configuration settings.</p>
-				
+
 				<p>This document lists examples of the personalized tools properties, an extension of <a href="../">WAI-Adapt Explainer</a>, including the properties of <code>messageimportance</code>, <code>messagefrom</code>, <code>messagecontext</code>, <code>messagetime</code>,	and <code>stepindicator</code>. </p>
-				
-				<p class="ednote" id="examples-disclaimer">WAI-Adapt defines a set of properties and values to annotate content. The specific mechanism to apply these properties to content and semantics has not been decided. <a href="https://github.com/w3c/personalization-semantics/wiki/Comparison-of-ways-to-use-vocabulary-in-content">Several approaches are under consideration</a> and future drafts will show progress. To help understand the proposed properties, this document provides many examples of WAI-Adapt applied to content, which show attributes beginning with the prefix "data-". <em>This prefix has not been decided on as the definitive approach</em>, but is used as a way to illustrate the examples.</p>
 			</section>
 			<section id="module">
 				<h2>WAI-Adapt: Tools Module</h2>
@@ -53,7 +51,7 @@
 				<p>Properties are the main units of WAI-Adapt types supported by the vocabulary. A given property supports a specific type of WAI-Adapt. That property would only be used once on a given piece of content, but multiple different properties could be used on the same piece of content to address different needs.</p>
 				</section>
 				<section id="propcharacteristic_value">
-				<h3 id="vocabulary_values">Values</h3> 
+				<h3 id="vocabulary_values">Values</h3>
 				<p>Values provide the specific personalization information for the property. The possible values for each property are elaborated in the definition of the property in the modules. Some properties require the value to come from a predefined list of possible values, others can accept arbitrary strings, and some may accept multiple values. The attribute value may be one of the following types:</p>
 				<dl>
 					<dt id="valuetype_idref">ID reference</dt>
@@ -76,7 +74,7 @@
 				</section>
 				<p><strong>Note that the attributes and values in this specification do not overide the semantics exposed in the accessibility tree, but rather augment them.</strong> In the case of conflict between an element's semantics and the attribute values, validation algorithms should issue a warning but not an error.</p>
 				 <div class="ednote">Since implementations have not yet been finalized, any examples in this document are illustrative only, and are provided to help in understanding the concept.  All examples will be updated once implementation examples are finalized.</div>
-			</section>		
+			</section>
 			<section id="usecases">
 				<h2>Use Cases and Requirements</h2>
 				<p>The <a href="https://github.com/w3c/personalization-semantics/wiki/Requirements">Requirements for Personalization Semantics</a> describes use cases and requirements. This module provides properties to fulfill requirements related to user support tools.</p>
@@ -88,8 +86,8 @@
 		</section>
 		<section id="vocabulary">
 			<h1>Vocabulary</h1>
-			<section data-include="log.html" data-include-replace="true" id="log"></section>	
-			<section data-include="message.html" data-include-replace="true" id="message"></section>		
+			<section data-include="log.html" data-include-replace="true" id="log"></section>
+			<section data-include="message.html" data-include-replace="true" id="message"></section>
 		</section>
 		<section id="privacy">
 			<h1>Privacy and Security Considerations</h1>

--- a/tools/log.html
+++ b/tools/log.html
@@ -15,26 +15,26 @@
     <h4>Example</h4>
   	<p>Note, the specific mechanism to apply these defined values has not been decided:</p>
     <pre class="example" title="stepindicator using data-">
-      &lt;div data-stepindicator=&quot;book trip&quot;&gt;
-        &lt;div data-status=&quot;complete&quot; aria-label=&quot;select flight&quot; data-step=&quot;1&quot; data-steplocation=&quot;uri&quot; /&gt;
-        &lt;div data-status=&quot;current&quot; aria-label=&quot;book hotel&quot; data-step=&quot;2&quot; data-steplocation=&quot;uri&quot; /&gt;
-        &lt;div data-status=&quot;&quot; aria-label=&quot;book car&quot; data-step=&quot;3&quot; data-steplocation=&quot;uri&quot; /&gt;
-        &lt;div data-status=&quot;&quot; aria-label=&quot;purchase trip&quot; data-step=&quot;4&quot; steplocation=&quot;uri&quot; /&gt;
+      &lt;div adapt-stepindicator=&quot;book trip&quot;&gt;
+        &lt;div adapt-status=&quot;complete&quot; aria-label=&quot;select flight&quot; adapt-step=&quot;1&quot; adapt-steplocation=&quot;uri&quot; /&gt;
+        &lt;div adapt-status=&quot;current&quot; aria-label=&quot;book hotel&quot; adapt-step=&quot;2&quot; adapt-steplocation=&quot;uri&quot; /&gt;
+        &lt;div adapt-status=&quot;&quot; aria-label=&quot;book car&quot; adapt-step=&quot;3&quot; adapt-steplocation=&quot;uri&quot; /&gt;
+        &lt;div adapt-status=&quot;&quot; aria-label=&quot;purchase trip&quot; adapt-step=&quot;4&quot; steplocation=&quot;uri&quot; /&gt;
       &lt;/div&gt;
 
       <p>or the step number can be implied by the DOM</p>
 
-        &lt;div data-stepindicator=&quot;book trip&quot;&gt;
-          &lt;div data-status=&quot;complete&quot; aria-labelledby=&quot;select flight&quot;&gt;
+        &lt;div adapt-stepindicator=&quot;book trip&quot;&gt;
+          &lt;div adapt-status=&quot;complete&quot; aria-labelledby=&quot;select flight&quot;&gt;
             &lt;a href=&quot;uri&quot;>Select flight&lt;/a&gt;
           &lt;/div&gt;
-          &lt;div data-status=&quot;current&quot; aria-labelledby=&quot;book hotel&quot;&gt;
+          &lt;div adapt-status=&quot;current&quot; aria-labelledby=&quot;book hotel&quot;&gt;
             &lt;a href=&quot;uri&quot;>Book Hotel&lt;/a&gt;
           &lt;/div&gt;
-          &lt;div data-status=&quot;&quot; aria-labelledby=&quot;book car&quot;&gt;
+          &lt;div adapt-status=&quot;&quot; aria-labelledby=&quot;book car&quot;&gt;
             &lt;a href=&quot;uri&quot;>Book car&lt;/a&gt;
           &lt;/div&gt;
-          &lt;div data-status=&quot;&quot; aria-labelledby=&quot;purchase trip&quot;&gt;
+          &lt;div adapt-status=&quot;&quot; aria-labelledby=&quot;purchase trip&quot;&gt;
             &lt;a href=&quot;uri&quot;>Purchase trip&lt;/a&gt;
           &lt;/div&gt;
         &lt;/div&gt;    

--- a/tools/log.html
+++ b/tools/log.html
@@ -14,7 +14,7 @@
   <section id="stepindicator-usage-example">
     <h4>Example</h4>
   	<p>Note, the specific mechanism to apply these defined values has not been decided:</p>
-    <pre class="example" title="stepindicator using data-">
+    <pre class="example" title="stepindicator using adapt-">
       &lt;div adapt-stepindicator=&quot;book trip&quot;&gt;
         &lt;div adapt-status=&quot;complete&quot; aria-label=&quot;select flight&quot; adapt-step=&quot;1&quot; adapt-steplocation=&quot;uri&quot; /&gt;
         &lt;div adapt-status=&quot;current&quot; aria-label=&quot;book hotel&quot; adapt-step=&quot;2&quot; adapt-steplocation=&quot;uri&quot; /&gt;

--- a/tools/message.html
+++ b/tools/message.html
@@ -15,7 +15,7 @@
     <h4>Example</h4>
 	  <p>The specific mechanism to apply these defined values has not been decided</p>
     <pre class="example" title="messageimportance using data-">
-        &lt;div role=&quot;alert&quot; data-messageimportance=&quot;medium&quot;&gt;
+        &lt;div role=&quot;alert&quot; adapt-messageimportance=&quot;medium&quot;&gt;
             It is your daughter&apos;s birthday tomorrow
         &lt;/div&gt;
     </pre>
@@ -93,8 +93,8 @@
     <h4>Example</h4>
 	<p>The specific mechanism to apply these defined values has not been decided</p>
     <pre class="example" title="messagefrom using data-">
-        &lt;div role=&quot;alert&quot; data-messageimportance=&quot;low&quot;
-            data-messagefrom=&quot;lisa seeman, lseeman&quot;&gt;
+        &lt;div role=&quot;alert&quot; adapt-messageimportance=&quot;low&quot;
+            adapt-messagefrom=&quot;lisa seeman, lseeman&quot;&gt;
             I posted a new version on GitHub for you to review
         &lt;/div&gt;
         </pre>
@@ -148,9 +148,9 @@
 	<p>The specific mechanism to apply these defined values has not been decided</p>
     <pre class="example" title="messagecontext using data-">
     &lt;div role=&quot;alert&quot;
-        data-messageimportance=&quot;low&quot;
-        data-messagefrom=&quot;lisa seeman, lseeman&quot;
-        data-messagecontext=&quot;work&quot;&gt;
+        adapt-messageimportance=&quot;low&quot;
+        adapt-messagefrom=&quot;lisa seeman, lseeman&quot;
+        adapt-messagecontext=&quot;work&quot;&gt;
         I posted a new version on GitHub for you to review
     &lt;/div&gt;
     </pre>
@@ -202,18 +202,18 @@
   <p>@@1-line description</p>
     <pre class="example" title="messagetime using data-">
     &lt;div role=&quot;alert&quot;
-        data-messageimportance=&quot;medium&quot;
-        data-messagefrom=&quot;my calender&quot;
-        data-messagecontext=&quot;work&quot;
-        data-messagetime=&quot;10.02.2017.00.00-16.02.2017.00.00&quot;&gt;
+        adapt-messageimportance=&quot;medium&quot;
+        adapt-messagefrom=&quot;my calender&quot;
+        adapt-messagecontext=&quot;work&quot;
+        adapt-messagetime=&quot;10.02.2017.00.00-16.02.2017.00.00&quot;&gt;
         Renew your driving license this week
     &lt;/div&gt;
 <p></p>
     &lt;div role=&quot;alert&quot;
-        data-messageimportance=&quot;critical&quot;
-        data-messagefrom=&quot;my calender&quot;
-        data-messagecontext=&quot;work&quot;
-        data-messagetime=&quot;16.02.2017.00.00&quot;&gt;
+        adapt-messageimportance=&quot;critical&quot;
+        adapt-messagefrom=&quot;my calender&quot;
+        adapt-messagecontext=&quot;work&quot;
+        adapt-messagetime=&quot;16.02.2017.00.00&quot;&gt;
         Renew your driving license ASAP
     &lt;/div&gt;
     </pre>

--- a/tools/message.html
+++ b/tools/message.html
@@ -14,7 +14,7 @@
   <section id="messageimportance-example">
     <h4>Example</h4>
 	  <p>The specific mechanism to apply these defined values has not been decided</p>
-    <pre class="example" title="messageimportance using data-">
+    <pre class="example" title="messageimportance using adapt-">
         &lt;div role=&quot;alert&quot; adapt-messageimportance=&quot;medium&quot;&gt;
             It is your daughter&apos;s birthday tomorrow
         &lt;/div&gt;
@@ -92,7 +92,7 @@
 	<section id="messagefrom-example">
     <h4>Example</h4>
 	<p>The specific mechanism to apply these defined values has not been decided</p>
-    <pre class="example" title="messagefrom using data-">
+    <pre class="example" title="messagefrom using adapt-">
         &lt;div role=&quot;alert&quot; adapt-messageimportance=&quot;low&quot;
             adapt-messagefrom=&quot;lisa seeman, lseeman&quot;&gt;
             I posted a new version on GitHub for you to review
@@ -146,7 +146,7 @@
   <section id="messagecontext-example">
     <h4>Example</h4>
 	<p>The specific mechanism to apply these defined values has not been decided</p>
-    <pre class="example" title="messagecontext using data-">
+    <pre class="example" title="messagecontext using adapt-">
     &lt;div role=&quot;alert&quot;
         adapt-messageimportance=&quot;low&quot;
         adapt-messagefrom=&quot;lisa seeman, lseeman&quot;
@@ -200,7 +200,7 @@
   <h3>messagetime</h3>
 	  <p>The specific mechanism to apply these defined values has not been decided</p>
   <p>@@1-line description</p>
-    <pre class="example" title="messagetime using data-">
+    <pre class="example" title="messagetime using adapt-">
     &lt;div role=&quot;alert&quot;
         adapt-messageimportance=&quot;medium&quot;
         adapt-messagefrom=&quot;my calender&quot;


### PR DESCRIPTION
As per [today's action on me](https://www.w3.org/2022/10/31-adapt-minutes#a06).

* Rename `data-*` attributes to `adapt-*` attributes.
* Fix the `title`s of some of the examples, both in line with the rename, and in terms of capitalisation.

Previews:
* [Explainer (public)](https://raw.githack.com/w3c/adapt/data-attribute-rename/index.html)
* [Content module](https://raw.githack.com/w3c/adapt/data-attribute-rename/content/index.html)
* [Help module](https://raw.githack.com/w3c/adapt/data-attribute-rename/help/index.html)
* [Tools module](https://raw.githack.com/w3c/adapt/data-attribute-rename/tools/index.html)