### PR TITLE
rename `symbol` to `adapt-symbol`

### DIFF
--- a/symbols/symbol.html
+++ b/symbols/symbol.html
@@ -3,8 +3,8 @@
 	<section>
 		<h3>Description</h3>
 		<div class="property-description">
-			<p>The <code>symbol</code> attribute identifies the concept for symbols used in <abbr title="Augmentative and Alternative Communication">AAC</abbr> devices, etc., for users who cannot process traditional written language. The symbols are an alternative vocabulary, and multiple symbol sets exist today. These various symbol sets are, unfortunately, not mutually comprehensible so the individual familiar with expression via symbol set alpha is unable to understand expressions using symbol set beta. This specification exists to provide a web-based technological mechanism to select appropriate symbols from the set an individual user knows by using the <abbr title="Blissymbolics Communication International">BCI</abbr> concept index, the current de facto standard for cross referencing symbolic representations among symbol sets extant in the world today.</p>
-			<p>The <code>symbol</code> attribute accepts a numeric reference number.</p>
+			<p>The <code>adapt-symbol</code> attribute identifies the concept for symbols used in <abbr title="Augmentative and Alternative Communication">AAC</abbr> devices, etc., for users who cannot process traditional written language. The symbols are an alternative vocabulary, and multiple symbol sets exist today. These various symbol sets are, unfortunately, not mutually comprehensible so the individual familiar with expression via symbol set alpha is unable to understand expressions using symbol set beta. This specification exists to provide a web-based technological mechanism to select appropriate symbols from the set an individual user knows by using the <abbr title="Blissymbolics Communication International">BCI</abbr> concept index, the current de facto standard for cross referencing symbolic representations among symbol sets extant in the world today.</p>
+			<p>The <code>adapt-symbol</code> attribute accepts a numeric reference number.</p>
 			<p>A personalization-aware user agent can then augment or transform User Interfaces by:</p>
 			<ul>
 				<li>converting content author text, annotated using numeric values from the <abbr title="Blissymbolics Communication International">BCI</abbr> concept index into  symbols in the user&apos;s preferred set,</li>
@@ -33,7 +33,7 @@
 	</section>
 	<section id="symbol-example">
 		<h3>Examples</h3>
-		<p>Here are some examples using the <code>symbol</code> attribute.</p>
+		<p>Here are some examples using the <code>adapt-symbol</code> attribute.</p>
 		<ol>
 			<li>Symbols for individual words.
 				<pre class="example" title="Symbols for individual words">&lt;span adapt-symbol=&quot;13621&quot;&gt;Cup&lt;/span&gt; of &lt;span adapt-symbol=&quot;17511&quot;&gt;Tea&lt;/span&gt;</pre>


### PR DESCRIPTION
Note: this only affects the Symbols module. The attribute name is found in
other files in the repo, but it does not look like we still use them.
