### PR TITLE
Tweak the `adapt-purpose` example

### DIFF
--- a/index.html
+++ b/index.html
@@ -134,8 +134,8 @@
 			<div class="example"><p>Example: Using the <code>adapt-symbol</code> attribute, an author programmatically tags the label for a form input with the appropriate symbol value. Based on user preference settings, a browser helper application or stand-alone tool could then render that label using an appropriate symbol, alternative term, and/or furnishes an additional tool-tip that is understandable by the individual user. Using the <a href="https://www.blissymbolics.org/">Bliss Symbolics</a> set's unique reference numbers as our 'taxonomy', other symbol sets can map their equivalent symbols against the Bliss set.</p>
 
 			<code>
-			&lt;label for="bar" <strong>adapt-symbol="14885"</strong>&gt;Your Principle Residence&lt;/label&gt; <br>
-			&lt;input type="textarea" id="bar" name="address" adapt-purpose="street-address"&gt;
+			&lt;label for="address" <strong>adapt-symbol="14885"</strong>&gt;Your Principal Residence&lt;/label&gt; <br>
+			&lt;input type="textarea" id="address" adapt-purpose="street-address"&gt;
 			</code>
 			<p>Where the symbol value 14855 maps back to "Home".</p>
 			</div>


### PR DESCRIPTION
* Rename the `id` value to something more fitting.
* Remove redundant (for these purposes) `name` attribute.
* Correct a typo.

Note:
* This may be more apt using the `home` modifier, if we support it?
