### PR TITLE
GitHub actions: Replace ubuntu-20.04 with ubuntu-latest

### DIFF
--- a/.github/workflows/auto-publish.yml
+++ b/.github/workflows/auto-publish.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   main:
     name: Build, Validate and Deploy
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: w3c/spec-prod@v2


### PR DESCRIPTION
The Ubuntu 20.04 runner image is no longer supported. This updates the GitHub action in this repo to unblock future builds.